### PR TITLE
blockchain RPC compatiblity

### DIFF
--- a/infrastructure.go
+++ b/infrastructure.go
@@ -1047,6 +1047,10 @@ type ConnConfig struct {
 	// however, not all servers support the websocket extensions, so this
 	// flag can be set to true to use basic HTTP POST requests instead.
 	HttpPostMode bool
+
+	// EnableBCInfoHacks is an option provided to enable compatiblity hacks
+	// when connecting to blockchain.info RPC server
+	EnableBCInfoHacks bool
 }
 
 // newHTTPClient returns a new http client that is configured according to the


### PR DESCRIPTION
refs #17 

used the approach mentioned by @davecgh i.e added a `EnableBCInfoHacks` config flag which is `false` by default. When enabled, the required client methods can dispatch to a variant of the original receiver. Not sure if there's a better way than repeating this for all `GetBalance*` commands, so looking into it.
