### PR TITLE
Update to make use of version 2 of btcjson.

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -476,7 +476,7 @@ func (r FutureGetTxOutResult) Receive() (*btcjson.GetTxOutResult, error) {
 // the returned instance.
 //
 // See GetTxOut for the blocking version and more details.
-func (c *Client) GetTxOutAsync(txHash *wire.ShaHash, index int, mempool bool) FutureGetTxOutResult {
+func (c *Client) GetTxOutAsync(txHash *wire.ShaHash, index uint32, mempool bool) FutureGetTxOutResult {
 	hash := ""
 	if txHash != nil {
 		hash = txHash.String()
@@ -488,6 +488,6 @@ func (c *Client) GetTxOutAsync(txHash *wire.ShaHash, index int, mempool bool) Fu
 
 // GetTxOut returns the transaction output info if it's unspent and
 // nil, otherwise.
-func (c *Client) GetTxOut(txHash *wire.ShaHash, index int, mempool bool) (*btcjson.GetTxOutResult, error) {
+func (c *Client) GetTxOut(txHash *wire.ShaHash, index uint32, mempool bool) (*btcjson.GetTxOutResult, error) {
 	return c.GetTxOutAsync(txHash, index, mempool).Receive()
 }

--- a/chain.go
+++ b/chain.go
@@ -9,7 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 
-	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcjson/v2/btcjson"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 )
@@ -41,12 +41,7 @@ func (r FutureGetBestBlockHashResult) Receive() (*wire.ShaHash, error) {
 //
 // See GetBestBlockHash for the blocking version and more details.
 func (c *Client) GetBestBlockHashAsync() FutureGetBestBlockHashResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetBestBlockHashCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetBestBlockHashCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -101,12 +96,7 @@ func (c *Client) GetBlockAsync(blockHash *wire.ShaHash) FutureGetBlockResult {
 		hash = blockHash.String()
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewGetBlockCmd(id, hash, false)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Bool(false), nil)
 	return c.sendCmd(cmd)
 }
 
@@ -124,14 +114,14 @@ type FutureGetBlockVerboseResult chan *response
 
 // Receive waits for the response promised by the future and returns the data
 // structure from the server with information about the requested block.
-func (r FutureGetBlockVerboseResult) Receive() (*btcjson.BlockResult, error) {
+func (r FutureGetBlockVerboseResult) Receive() (*btcjson.GetBlockVerboseResult, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
 	}
 
 	// Unmarshal the raw result into a BlockResult.
-	var blockResult btcjson.BlockResult
+	var blockResult btcjson.GetBlockVerboseResult
 	err = json.Unmarshal(res, &blockResult)
 	if err != nil {
 		return nil, err
@@ -150,12 +140,7 @@ func (c *Client) GetBlockVerboseAsync(blockHash *wire.ShaHash, verboseTx bool) F
 		hash = blockHash.String()
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewGetBlockCmd(id, hash, true, verboseTx)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Bool(true), &verboseTx)
 	return c.sendCmd(cmd)
 }
 
@@ -163,7 +148,7 @@ func (c *Client) GetBlockVerboseAsync(blockHash *wire.ShaHash, verboseTx bool) F
 // about a block given its hash.
 //
 // See GetBlock to retrieve a raw block instead.
-func (c *Client) GetBlockVerbose(blockHash *wire.ShaHash, verboseTx bool) (*btcjson.BlockResult, error) {
+func (c *Client) GetBlockVerbose(blockHash *wire.ShaHash, verboseTx bool) (*btcjson.GetBlockVerboseResult, error) {
 	return c.GetBlockVerboseAsync(blockHash, verboseTx).Receive()
 }
 
@@ -194,12 +179,7 @@ func (r FutureGetBlockCountResult) Receive() (int64, error) {
 //
 // See GetBlockCount for the blocking version and more details.
 func (c *Client) GetBlockCountAsync() FutureGetBlockCountResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetBlockCountCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetBlockCountCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -235,12 +215,7 @@ func (r FutureGetDifficultyResult) Receive() (float64, error) {
 //
 // See GetDifficulty for the blocking version and more details.
 func (c *Client) GetDifficultyAsync() FutureGetDifficultyResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetDifficultyCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetDifficultyCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -277,12 +252,7 @@ func (r FutureGetBlockHashResult) Receive() (*wire.ShaHash, error) {
 //
 // See GetBlockHash for the blocking version and more details.
 func (c *Client) GetBlockHashAsync(blockHeight int64) FutureGetBlockHashResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetBlockHashCmd(id, blockHeight)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetBlockHashCmd(blockHeight)
 	return c.sendCmd(cmd)
 }
 
@@ -330,12 +300,7 @@ func (r FutureGetRawMempoolResult) Receive() ([]*wire.ShaHash, error) {
 //
 // See GetRawMempool for the blocking version and more details.
 func (c *Client) GetRawMempoolAsync() FutureGetRawMempoolResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetRawMempoolCmd(id, false)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetRawMempoolCmd(btcjson.Bool(false))
 	return c.sendCmd(cmd)
 }
 
@@ -354,7 +319,7 @@ type FutureGetRawMempoolVerboseResult chan *response
 // Receive waits for the response promised by the future and returns a map of
 // transaction hashes to an associated data structure with information about the
 // transaction for all transactions in the memory pool.
-func (r FutureGetRawMempoolVerboseResult) Receive() (map[string]btcjson.GetRawMempoolResult, error) {
+func (r FutureGetRawMempoolVerboseResult) Receive() (map[string]btcjson.GetRawMempoolVerboseResult, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
@@ -362,7 +327,7 @@ func (r FutureGetRawMempoolVerboseResult) Receive() (map[string]btcjson.GetRawMe
 
 	// Unmarshal the result as a map of strings (tx shas) to their detailed
 	// results.
-	var mempoolItems map[string]btcjson.GetRawMempoolResult
+	var mempoolItems map[string]btcjson.GetRawMempoolVerboseResult
 	err = json.Unmarshal(res, &mempoolItems)
 	if err != nil {
 		return nil, err
@@ -376,12 +341,7 @@ func (r FutureGetRawMempoolVerboseResult) Receive() (map[string]btcjson.GetRawMe
 //
 // See GetRawMempoolVerbose for the blocking version and more details.
 func (c *Client) GetRawMempoolVerboseAsync() FutureGetRawMempoolVerboseResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetRawMempoolCmd(id, true)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetRawMempoolCmd(btcjson.Bool(true))
 	return c.sendCmd(cmd)
 }
 
@@ -390,7 +350,7 @@ func (c *Client) GetRawMempoolVerboseAsync() FutureGetRawMempoolVerboseResult {
 // the memory pool.
 //
 // See GetRawMempool to retrieve only the transaction hashes instead.
-func (c *Client) GetRawMempoolVerbose() (map[string]btcjson.GetRawMempoolResult, error) {
+func (c *Client) GetRawMempoolVerbose() (map[string]btcjson.GetRawMempoolVerboseResult, error) {
 	return c.GetRawMempoolVerboseAsync().Receive()
 }
 
@@ -423,12 +383,7 @@ func (r FutureVerifyChainResult) Receive() (bool, error) {
 //
 // See VerifyChain for the blocking version and more details.
 func (c *Client) VerifyChainAsync() FutureVerifyChainResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewVerifyChainCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewVerifyChainCmd(nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -446,12 +401,7 @@ func (c *Client) VerifyChain() (bool, error) {
 //
 // See VerifyChainLevel for the blocking version and more details.
 func (c *Client) VerifyChainLevelAsync(checkLevel int32) FutureVerifyChainResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewVerifyChainCmd(id, checkLevel)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewVerifyChainCmd(&checkLevel, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -474,12 +424,7 @@ func (c *Client) VerifyChainLevel(checkLevel int32) (bool, error) {
 //
 // See VerifyChainBlocks for the blocking version and more details.
 func (c *Client) VerifyChainBlocksAsync(checkLevel, numBlocks int32) FutureVerifyChainResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewVerifyChainCmd(id, checkLevel, numBlocks)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewVerifyChainCmd(&checkLevel, &numBlocks)
 	return c.sendCmd(cmd)
 }
 
@@ -537,11 +482,7 @@ func (c *Client) GetTxOutAsync(txHash *wire.ShaHash, index int, mempool bool) Fu
 		hash = txHash.String()
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewGetTxOutCmd(id, hash, index, mempool)
-	if err != nil {
-		return newFutureError(err)
-	}
+	cmd := btcjson.NewGetTxOutCmd(hash, index, &mempool)
 	return c.sendCmd(cmd)
 }
 

--- a/doc.go
+++ b/doc.go
@@ -141,14 +141,14 @@ the type can vary, but usually will be best handled by simply showing/logging
 it.
 
 The third category of errors, that is errors returned by the server, can be
-detected by type asserting the error in a *btcjson.Error.  For example, to
+detected by type asserting the error in a *btcjson.RPCError.  For example, to
 detect if a command is unimplemented by the remote RPC server:
 
   amount, err := client.GetBalance("")
   if err != nil {
-  	if jerr, ok := err.(*btcjson.Error); ok {
+  	if jerr, ok := err.(*btcjson.RPCError); ok {
   		switch jerr.Code {
-		case btcjson.ErrUnimplemented.Code:
+  		case btcjson.ErrRPCUnimplemented:
   			// Handle not implemented error
 
   		// Handle other specific errors you care about

--- a/examples/bitcoincorehttp/main.go
+++ b/examples/bitcoincorehttp/main.go
@@ -16,7 +16,7 @@ func main() {
 		Host:         "localhost:8332",
 		User:         "yourrpcuser",
 		Pass:         "yourrpcpass",
-		HttpPostMode: true, // Bitcoin core only supports HTTP POST mode
+		HTTPPostMode: true, // Bitcoin core only supports HTTP POST mode
 		DisableTLS:   true, // Bitcoin core does not provide TLS by default
 	}
 	// Notice the notification parameter is nil since notifications are

--- a/extensions.go
+++ b/extensions.go
@@ -9,8 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/btcsuite/btcd/btcjson"
-	"github.com/btcsuite/btcd/btcjson/btcws"
+	"github.com/btcsuite/btcd/btcjson/v2/btcjson"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 )
@@ -45,12 +44,7 @@ func (r FutureDebugLevelResult) Receive() (string, error) {
 //
 // NOTE: This is a btcd extension.
 func (c *Client) DebugLevelAsync(levelSpec string) FutureDebugLevelResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewDebugLevelCmd(id, levelSpec)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewDebugLevelCmd(levelSpec)
 	return c.sendCmd(cmd)
 }
 
@@ -86,8 +80,7 @@ func (r FutureCreateEncryptedWalletResult) Receive() error {
 //
 // NOTE: This is a btcwallet extension.
 func (c *Client) CreateEncryptedWalletAsync(passphrase string) FutureCreateEncryptedWalletResult {
-	id := c.NextID()
-	cmd := btcws.NewCreateEncryptedWalletCmd(id, passphrase)
+	cmd := btcjson.NewCreateEncryptedWalletCmd(passphrase)
 	return c.sendCmd(cmd)
 }
 
@@ -137,12 +130,7 @@ func (c *Client) ListAddressTransactionsAsync(addresses []btcutil.Address, accou
 	for _, addr := range addresses {
 		addrs = append(addrs, addr.EncodeAddress())
 	}
-	id := c.NextID()
-	cmd, err := btcws.NewListAddressTransactionsCmd(id, addrs, account)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListAddressTransactionsCmd(addrs, &account)
 	return c.sendCmd(cmd)
 }
 
@@ -167,7 +155,7 @@ func (r FutureGetBestBlockResult) Receive() (*wire.ShaHash, int32, error) {
 	}
 
 	// Unmarsal result as a getbestblock result object.
-	var bestBlock btcws.GetBestBlockResult
+	var bestBlock btcjson.GetBestBlockResult
 	err = json.Unmarshal(res, &bestBlock)
 	if err != nil {
 		return nil, 0, err
@@ -190,9 +178,7 @@ func (r FutureGetBestBlockResult) Receive() (*wire.ShaHash, int32, error) {
 //
 // NOTE: This is a btcd extension.
 func (c *Client) GetBestBlockAsync() FutureGetBestBlockResult {
-	id := c.NextID()
-	cmd := btcws.NewGetBestBlockCmd(id)
-
+	cmd := btcjson.NewGetBestBlockCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -234,9 +220,7 @@ func (r FutureGetCurrentNetResult) Receive() (wire.BitcoinNet, error) {
 //
 // NOTE: This is a btcd extension.
 func (c *Client) GetCurrentNetAsync() FutureGetCurrentNetResult {
-	id := c.NextID()
-	cmd := btcws.NewGetCurrentNetCmd(id)
-
+	cmd := btcjson.NewGetCurrentNetCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -302,12 +286,7 @@ func (r FutureExportWatchingWalletResult) Receive() ([]byte, []byte, error) {
 //
 // NOTE: This is a btcwallet extension.
 func (c *Client) ExportWatchingWalletAsync(account string) FutureExportWatchingWalletResult {
-	id := c.NextID()
-	cmd, err := btcws.NewExportWatchingWalletCmd(id, account, true)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewExportWatchingWalletCmd(&account, btcjson.Bool(true))
 	return c.sendCmd(cmd)
 }
 

--- a/goclean.sh
+++ b/goclean.sh
@@ -11,7 +11,7 @@ set -e
 # Automatic checks
 test -z "$(gofmt -l -w .     | tee /dev/stderr)"
 test -z "$(goimports -l -w . | tee /dev/stderr)"
-#test -z "$(golint .          | tee /dev/stderr)"
+test -z "$(golint .          | tee /dev/stderr)"
 go vet ./...
 env GORACE="halt_on_error=1" go test -v -race ./...
 

--- a/infrastructure.go
+++ b/infrastructure.go
@@ -789,7 +789,7 @@ func (c *Client) sendRequest(jReq *jsonRequest) {
 	// the client running in HTTP POST mode or not.  When running in HTTP
 	// POST mode, the command is issued via an HTTP client.  Otherwise,
 	// the command is issued via the asynchronous websocket channels.
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		c.sendPost(jReq)
 		return
 	}
@@ -876,7 +876,7 @@ func (c *Client) Disconnected() bool {
 //
 // This function is safe for concurrent access.
 func (c *Client) doDisconnect() bool {
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		return false
 	}
 
@@ -979,7 +979,7 @@ func (c *Client) start() {
 
 	// Start the I/O processing handlers depending on whether the client is
 	// in HTTP POST mode or the default websocket mode.
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		c.wg.Add(1)
 		go c.sendPostHandler()
 	} else {
@@ -1055,13 +1055,13 @@ type ConnConfig struct {
 	// called manually.
 	DisableConnectOnNew bool
 
-	// HttpPostMode instructs the client to run using multiple independent
+	// HTTPPostMode instructs the client to run using multiple independent
 	// connections issuing HTTP POST requests instead of using the default
 	// of websockets.  Websockets are generally preferred as some of the
 	// features of the client such notifications only work with websockets,
 	// however, not all servers support the websocket extensions, so this
 	// flag can be set to true to use basic HTTP POST requests instead.
-	HttpPostMode bool
+	HTTPPostMode bool
 
 	// EnableBCInfoHacks is an option provided to enable compatiblity hacks
 	// when connecting to blockchain.info RPC server
@@ -1182,7 +1182,7 @@ func New(config *ConnConfig, ntfnHandlers *NotificationHandlers) (*Client, error
 	var httpClient *http.Client
 	connEstablished := make(chan struct{})
 	var start bool
-	if config.HttpPostMode {
+	if config.HTTPPostMode {
 		ntfnHandlers = nil
 		start = true
 
@@ -1222,7 +1222,7 @@ func New(config *ConnConfig, ntfnHandlers *NotificationHandlers) (*Client, error
 	if start {
 		close(connEstablished)
 		client.start()
-		if !client.config.HttpPostMode && !client.config.DisableAutoReconnect {
+		if !client.config.HTTPPostMode && !client.config.DisableAutoReconnect {
 			client.wg.Add(1)
 			go client.wsReconnectHandler()
 		}
@@ -1246,7 +1246,7 @@ func (c *Client) Connect(tries int) error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		return ErrNotWebsocketClient
 	}
 	if c.wsConn != nil {

--- a/mining.go
+++ b/mining.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcjson/v2/btcjson"
 	"github.com/btcsuite/btcutil"
 )
 
@@ -41,12 +41,7 @@ func (r FutureGetGenerateResult) Receive() (bool, error) {
 //
 // See GetGenerate for the blocking version and more details.
 func (c *Client) GetGenerateAsync() FutureGetGenerateResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetGenerateCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetGenerateCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -76,12 +71,7 @@ func (r FutureSetGenerateResult) Receive() error {
 //
 // See SetGenerate for the blocking version and more details.
 func (c *Client) SetGenerateAsync(enable bool, numCPUs int) FutureSetGenerateResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewSetGenerateCmd(id, enable, numCPUs)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSetGenerateCmd(enable, &numCPUs)
 	return c.sendCmd(cmd)
 }
 
@@ -119,12 +109,7 @@ func (r FutureGetHashesPerSecResult) Receive() (int64, error) {
 //
 // See GetHashesPerSec for the blocking version and more details.
 func (c *Client) GetHashesPerSecAsync() FutureGetHashesPerSecResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetHashesPerSecCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetHashesPerSecCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -163,12 +148,7 @@ func (r FutureGetMiningInfoResult) Receive() (*btcjson.GetMiningInfoResult, erro
 //
 // See GetMiningInfo for the blocking version and more details.
 func (c *Client) GetMiningInfoAsync() FutureGetMiningInfoResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetMiningInfoCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetMiningInfoCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -206,12 +186,7 @@ func (r FutureGetNetworkHashPS) Receive() (int64, error) {
 //
 // See GetNetworkHashPS for the blocking version and more details.
 func (c *Client) GetNetworkHashPSAsync() FutureGetNetworkHashPS {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetNetworkHashPSCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetNetworkHashPSCmd(nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -230,12 +205,7 @@ func (c *Client) GetNetworkHashPS() (int64, error) {
 //
 // See GetNetworkHashPS2 for the blocking version and more details.
 func (c *Client) GetNetworkHashPS2Async(blocks int) FutureGetNetworkHashPS {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetNetworkHashPSCmd(id, blocks)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetNetworkHashPSCmd(&blocks, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -256,12 +226,7 @@ func (c *Client) GetNetworkHashPS2(blocks int) (int64, error) {
 //
 // See GetNetworkHashPS3 for the blocking version and more details.
 func (c *Client) GetNetworkHashPS3Async(blocks, height int) FutureGetNetworkHashPS {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetNetworkHashPSCmd(id, blocks, height)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetNetworkHashPSCmd(&blocks, &height)
 	return c.sendCmd(cmd)
 }
 
@@ -303,12 +268,7 @@ func (r FutureGetWork) Receive() (*btcjson.GetWorkResult, error) {
 //
 // See GetWork for the blocking version and more details.
 func (c *Client) GetWorkAsync() FutureGetWork {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetWorkCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetWorkCmd(nil)
 	return c.sendCmd(cmd)
 }
 
@@ -347,12 +307,7 @@ func (r FutureGetWorkSubmit) Receive() (bool, error) {
 //
 // See GetWorkSubmit for the blocking version and more details.
 func (c *Client) GetWorkSubmitAsync(data string) FutureGetWorkSubmit {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetWorkCmd(id, data)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetWorkCmd(&data)
 	return c.sendCmd(cmd)
 }
 
@@ -406,12 +361,7 @@ func (c *Client) SubmitBlockAsync(block *btcutil.Block, options *btcjson.SubmitB
 		blockHex = hex.EncodeToString(blockBytes)
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewSubmitBlockCmd(id, blockHex, options)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSubmitBlockCmd(blockHex, options)
 	return c.sendCmd(cmd)
 }
 

--- a/net.go
+++ b/net.go
@@ -7,7 +7,7 @@ package btcrpcclient
 import (
 	"encoding/json"
 
-	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcjson/v2/btcjson"
 )
 
 // AddNodeCommand enumerates the available commands that the AddNode function
@@ -54,12 +54,7 @@ func (r FutureAddNodeResult) Receive() error {
 //
 // See AddNode for the blocking version and more details.
 func (c *Client) AddNodeAsync(host string, command AddNodeCommand) FutureAddNodeResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewAddNodeCmd(id, host, string(command))
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewAddNodeCmd(host, btcjson.AddNodeSubCmd(command))
 	return c.sendCmd(cmd)
 }
 
@@ -100,12 +95,7 @@ func (r FutureGetAddedNodeInfoResult) Receive() ([]btcjson.GetAddedNodeInfoResul
 //
 // See GetAddedNodeInfo for the blocking version and more details.
 func (c *Client) GetAddedNodeInfoAsync(peer string) FutureGetAddedNodeInfoResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetAddedNodeInfoCmd(id, true, peer)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetAddedNodeInfoCmd(true, &peer)
 	return c.sendCmd(cmd)
 }
 
@@ -145,12 +135,7 @@ func (r FutureGetAddedNodeInfoNoDNSResult) Receive() ([]string, error) {
 //
 // See GetAddedNodeInfoNoDNS for the blocking version and more details.
 func (c *Client) GetAddedNodeInfoNoDNSAsync(peer string) FutureGetAddedNodeInfoNoDNSResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetAddedNodeInfoCmd(id, false, peer)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetAddedNodeInfoCmd(false, &peer)
 	return c.sendCmd(cmd)
 }
 
@@ -191,12 +176,7 @@ func (r FutureGetConnectionCountResult) Receive() (int64, error) {
 //
 // See GetConnectionCount for the blocking version and more details.
 func (c *Client) GetConnectionCountAsync() FutureGetConnectionCountResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetConnectionCountCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetConnectionCountCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -226,12 +206,7 @@ func (r FuturePingResult) Receive() error {
 //
 // See Ping for the blocking version and more details.
 func (c *Client) PingAsync() FuturePingResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewPingCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewPingCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -271,12 +246,7 @@ func (r FutureGetPeerInfoResult) Receive() ([]btcjson.GetPeerInfoResult, error) 
 //
 // See GetPeerInfo for the blocking version and more details.
 func (c *Client) GetPeerInfoAsync() FutureGetPeerInfoResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetPeerInfoCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetPeerInfoCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -313,12 +283,7 @@ func (r FutureGetNetTotalsResult) Receive() (*btcjson.GetNetTotalsResult, error)
 //
 // See GetNetTotals for the blocking version and more details.
 func (c *Client) GetNetTotalsAsync() FutureGetNetTotalsResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetNetTotalsCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetNetTotalsCmd()
 	return c.sendCmd(cmd)
 }
 

--- a/notify.go
+++ b/notify.go
@@ -666,7 +666,7 @@ func (r FutureNotifyBlocksResult) Receive() error {
 // NOTE: This is a btcd extension and requires a websocket connection.
 func (c *Client) NotifyBlocksAsync() FutureNotifyBlocksResult {
 	// Not supported in HTTP POST mode.
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		return newFutureError(ErrNotificationsNotSupported)
 	}
 
@@ -714,7 +714,7 @@ func (r FutureNotifySpentResult) Receive() error {
 // recreate the previous notification state on reconnect.
 func (c *Client) notifySpentInternal(outpoints []btcjson.OutPoint) FutureNotifySpentResult {
 	// Not supported in HTTP POST mode.
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		return newFutureError(ErrNotificationsNotSupported)
 	}
 
@@ -737,7 +737,7 @@ func (c *Client) notifySpentInternal(outpoints []btcjson.OutPoint) FutureNotifyS
 // NOTE: This is a btcd extension and requires a websocket connection.
 func (c *Client) NotifySpentAsync(outpoints []*wire.OutPoint) FutureNotifySpentResult {
 	// Not supported in HTTP POST mode.
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		return newFutureError(ErrNotificationsNotSupported)
 	}
 
@@ -793,7 +793,7 @@ func (r FutureNotifyNewTransactionsResult) Receive() error {
 // NOTE: This is a btcd extension and requires a websocket connection.
 func (c *Client) NotifyNewTransactionsAsync(verbose bool) FutureNotifyNewTransactionsResult {
 	// Not supported in HTTP POST mode.
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		return newFutureError(ErrNotificationsNotSupported)
 	}
 
@@ -842,7 +842,7 @@ func (r FutureNotifyReceivedResult) Receive() error {
 // recreate the previous notification state on reconnect.
 func (c *Client) notifyReceivedInternal(addresses []string) FutureNotifyReceivedResult {
 	// Not supported in HTTP POST mode.
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		return newFutureError(ErrNotificationsNotSupported)
 	}
 
@@ -866,7 +866,7 @@ func (c *Client) notifyReceivedInternal(addresses []string) FutureNotifyReceived
 // NOTE: This is a btcd extension and requires a websocket connection.
 func (c *Client) NotifyReceivedAsync(addresses []btcutil.Address) FutureNotifyReceivedResult {
 	// Not supported in HTTP POST mode.
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		return newFutureError(ErrNotificationsNotSupported)
 	}
 
@@ -939,7 +939,7 @@ func (c *Client) RescanAsync(startBlock *wire.ShaHash,
 	outpoints []*wire.OutPoint) FutureRescanResult {
 
 	// Not supported in HTTP POST mode.
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		return newFutureError(ErrNotificationsNotSupported)
 	}
 
@@ -1016,7 +1016,7 @@ func (c *Client) RescanEndBlockAsync(startBlock *wire.ShaHash,
 	endBlock *wire.ShaHash) FutureRescanResult {
 
 	// Not supported in HTTP POST mode.
-	if c.config.HttpPostMode {
+	if c.config.HTTPPostMode {
 		return newFutureError(ErrNotificationsNotSupported)
 	}
 

--- a/rawtransactions.go
+++ b/rawtransactions.go
@@ -9,7 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 
-	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcjson/v2/btcjson"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 )
@@ -101,12 +101,7 @@ func (c *Client) GetRawTransactionAsync(txHash *wire.ShaHash) FutureGetRawTransa
 		hash = txHash.String()
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewGetRawTransactionCmd(id, hash, 0)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetRawTransactionCmd(hash, btcjson.Int(0))
 	return c.sendCmd(cmd)
 }
 
@@ -152,12 +147,7 @@ func (c *Client) GetRawTransactionVerboseAsync(txHash *wire.ShaHash) FutureGetRa
 		hash = txHash.String()
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewGetRawTransactionCmd(id, hash, 1)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetRawTransactionCmd(hash, btcjson.Int(1))
 	return c.sendCmd(cmd)
 }
 
@@ -197,13 +187,8 @@ func (r FutureDecodeRawTransactionResult) Receive() (*btcjson.TxRawResult, error
 //
 // See DecodeRawTransaction for the blocking version and more details.
 func (c *Client) DecodeRawTransactionAsync(serializedTx []byte) FutureDecodeRawTransactionResult {
-	id := c.NextID()
 	txHex := hex.EncodeToString(serializedTx)
-	cmd, err := btcjson.NewDecodeRawTransactionCmd(id, txHex)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewDecodeRawTransactionCmd(txHex)
 	return c.sendCmd(cmd)
 }
 
@@ -255,16 +240,11 @@ func (r FutureCreateRawTransactionResult) Receive() (*wire.MsgTx, error) {
 func (c *Client) CreateRawTransactionAsync(inputs []btcjson.TransactionInput,
 	amounts map[btcutil.Address]btcutil.Amount) FutureCreateRawTransactionResult {
 
-	id := c.NextID()
-	convertedAmts := make(map[string]int64, len(amounts))
+	convertedAmts := make(map[string]float64, len(amounts))
 	for addr, amount := range amounts {
-		convertedAmts[addr.String()] = int64(amount)
+		convertedAmts[addr.String()] = amount.ToBTC()
 	}
-	cmd, err := btcjson.NewCreateRawTransactionCmd(id, inputs, convertedAmts)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewCreateRawTransactionCmd(inputs, convertedAmts)
 	return c.sendCmd(cmd)
 }
 
@@ -315,12 +295,7 @@ func (c *Client) SendRawTransactionAsync(tx *wire.MsgTx, allowHighFees bool) Fut
 		txHex = hex.EncodeToString(buf.Bytes())
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewSendRawTransactionCmd(id, txHex, allowHighFees)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSendRawTransactionCmd(txHex, &allowHighFees)
 	return c.sendCmd(cmd)
 }
 
@@ -381,12 +356,7 @@ func (c *Client) SignRawTransactionAsync(tx *wire.MsgTx) FutureSignRawTransactio
 		txHex = hex.EncodeToString(buf.Bytes())
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewSignRawTransactionCmd(id, txHex)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSignRawTransactionCmd(txHex, nil, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -417,12 +387,7 @@ func (c *Client) SignRawTransaction2Async(tx *wire.MsgTx, inputs []btcjson.RawTx
 		txHex = hex.EncodeToString(buf.Bytes())
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewSignRawTransactionCmd(id, txHex, inputs)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSignRawTransactionCmd(txHex, &inputs, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -459,13 +424,8 @@ func (c *Client) SignRawTransaction3Async(tx *wire.MsgTx,
 		txHex = hex.EncodeToString(buf.Bytes())
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewSignRawTransactionCmd(id, txHex, inputs,
-		privKeysWIF)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSignRawTransactionCmd(txHex, &inputs, &privKeysWIF,
+		nil)
 	return c.sendCmd(cmd)
 }
 
@@ -512,13 +472,8 @@ func (c *Client) SignRawTransaction4Async(tx *wire.MsgTx,
 		txHex = hex.EncodeToString(buf.Bytes())
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewSignRawTransactionCmd(id, txHex, inputs,
-		privKeysWIF, string(hashType))
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSignRawTransactionCmd(txHex, &inputs, &privKeysWIF,
+		btcjson.String(string(hashType)))
 	return c.sendCmd(cmd)
 }
 

--- a/wallet.go
+++ b/wallet.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/btcsuite/btcd/btcjson"
-	"github.com/btcsuite/btcd/btcjson/btcws"
+	"github.com/btcsuite/btcd/btcjson/v2/btcjson"
+
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -52,12 +52,7 @@ func (c *Client) GetTransactionAsync(txHash *wire.ShaHash) FutureGetTransactionR
 		hash = txHash.String()
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewGetTransactionCmd(id, hash)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetTransactionCmd(hash, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -97,12 +92,7 @@ func (r FutureListTransactionsResult) Receive() ([]btcjson.ListTransactionsResul
 //
 // See ListTransactions for the blocking version and more details.
 func (c *Client) ListTransactionsAsync(account string) FutureListTransactionsResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListTransactionsCmd(id, account)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListTransactionsCmd(&account, nil, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -120,12 +110,7 @@ func (c *Client) ListTransactions(account string) ([]btcjson.ListTransactionsRes
 //
 // See ListTransactionsCount for the blocking version and more details.
 func (c *Client) ListTransactionsCountAsync(account string, count int) FutureListTransactionsResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListTransactionsCmd(id, account, count)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListTransactionsCmd(&account, &count, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -144,12 +129,7 @@ func (c *Client) ListTransactionsCount(account string, count int) ([]btcjson.Lis
 //
 // See ListTransactionsCountFrom for the blocking version and more details.
 func (c *Client) ListTransactionsCountFromAsync(account string, count, from int) FutureListTransactionsResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListTransactionsCmd(id, account, count, from)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListTransactionsCmd(&account, &count, &from, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -193,12 +173,7 @@ func (r FutureListUnspentResult) Receive() ([]btcjson.ListUnspentResult, error) 
 //
 // See ListUnspent for the blocking version and more details.
 func (c *Client) ListUnspentAsync() FutureListUnspentResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListUnspentCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListUnspentCmd(nil, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -208,12 +183,7 @@ func (c *Client) ListUnspentAsync() FutureListUnspentResult {
 //
 // See ListUnspentMin for the blocking version and more details.
 func (c *Client) ListUnspentMinAsync(minConf int) FutureListUnspentResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListUnspentCmd(id, minConf)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListUnspentCmd(&minConf, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -223,12 +193,7 @@ func (c *Client) ListUnspentMinAsync(minConf int) FutureListUnspentResult {
 //
 // See ListUnspentMinMax for the blocking version and more details.
 func (c *Client) ListUnspentMinMaxAsync(minConf, maxConf int) FutureListUnspentResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListUnspentCmd(id, minConf, maxConf)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListUnspentCmd(&minConf, &maxConf, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -243,12 +208,7 @@ func (c *Client) ListUnspentMinMaxAddressesAsync(minConf, maxConf int, addrs []b
 		addrStrs = append(addrStrs, a.EncodeAddress())
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewListUnspentCmd(id, minConf, maxConf, addrStrs)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListUnspentCmd(&minConf, &maxConf, &addrStrs)
 	return c.sendCmd(cmd)
 }
 
@@ -315,12 +275,7 @@ func (c *Client) ListSinceBlockAsync(blockHash *wire.ShaHash) FutureListSinceBlo
 		hash = blockHash.String()
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewListSinceBlockCmd(id, hash)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListSinceBlockCmd(&hash, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -344,12 +299,7 @@ func (c *Client) ListSinceBlockMinConfAsync(blockHash *wire.ShaHash, minConfirms
 		hash = blockHash.String()
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewListSinceBlockCmd(id, hash, minConfirms)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListSinceBlockCmd(&hash, &minConfirms, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -383,7 +333,6 @@ func (r FutureLockUnspentResult) Receive() error {
 //
 // See LockUnspent for the blocking version and more details.
 func (c *Client) LockUnspentAsync(unlock bool, ops []*wire.OutPoint) FutureLockUnspentResult {
-	id := c.NextID()
 	outputs := make([]btcjson.TransactionInput, len(ops))
 	for i, op := range ops {
 		outputs[i] = btcjson.TransactionInput{
@@ -391,11 +340,7 @@ func (c *Client) LockUnspentAsync(unlock bool, ops []*wire.OutPoint) FutureLockU
 			Vout: op.Index,
 		}
 	}
-	cmd, err := btcjson.NewLockUnspentCmd(id, unlock, outputs)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewLockUnspentCmd(unlock, outputs)
 	return c.sendCmd(cmd)
 }
 
@@ -458,12 +403,7 @@ func (r FutureListLockUnspentResult) Receive() ([]*wire.OutPoint, error) {
 //
 // See ListLockUnspent for the blocking version and more details.
 func (c *Client) ListLockUnspentAsync() FutureListLockUnspentResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListLockUnspentCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListLockUnspentCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -496,12 +436,7 @@ func (r FutureSetTxFeeResult) Receive() error {
 //
 // See SetTxFee for the blocking version and more details.
 func (c *Client) SetTxFeeAsync(fee btcutil.Amount) FutureSetTxFeeResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewSetTxFeeCmd(id, int64(fee))
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSetTxFeeCmd(fee.ToBTC())
 	return c.sendCmd(cmd)
 }
 
@@ -539,13 +474,8 @@ func (r FutureSendToAddressResult) Receive() (*wire.ShaHash, error) {
 //
 // See SendToAddress for the blocking version and more details.
 func (c *Client) SendToAddressAsync(address btcutil.Address, amount btcutil.Amount) FutureSendToAddressResult {
-	id := c.NextID()
 	addr := address.EncodeAddress()
-	cmd, err := btcjson.NewSendToAddressCmd(id, addr, int64(amount))
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSendToAddressCmd(addr, amount.ToBTC(), nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -570,14 +500,9 @@ func (c *Client) SendToAddressCommentAsync(address btcutil.Address,
 	amount btcutil.Amount, comment,
 	commentTo string) FutureSendToAddressResult {
 
-	id := c.NextID()
 	addr := address.EncodeAddress()
-	cmd, err := btcjson.NewSendToAddressCmd(id, addr, int64(amount),
-		comment, commentTo)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSendToAddressCmd(addr, amount.ToBTC(), &comment,
+		&commentTo)
 	return c.sendCmd(cmd)
 }
 
@@ -628,13 +553,9 @@ func (r FutureSendFromResult) Receive() (*wire.ShaHash, error) {
 //
 // See SendFrom for the blocking version and more details.
 func (c *Client) SendFromAsync(fromAccount string, toAddress btcutil.Address, amount btcutil.Amount) FutureSendFromResult {
-	id := c.NextID()
 	addr := toAddress.EncodeAddress()
-	cmd, err := btcjson.NewSendFromCmd(id, fromAccount, addr, int64(amount))
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSendFromCmd(fromAccount, addr, amount.ToBTC(), nil,
+		nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -656,14 +577,9 @@ func (c *Client) SendFrom(fromAccount string, toAddress btcutil.Address, amount 
 //
 // See SendFromMinConf for the blocking version and more details.
 func (c *Client) SendFromMinConfAsync(fromAccount string, toAddress btcutil.Address, amount btcutil.Amount, minConfirms int) FutureSendFromResult {
-	id := c.NextID()
 	addr := toAddress.EncodeAddress()
-	cmd, err := btcjson.NewSendFromCmd(id, fromAccount, addr, int64(amount),
-		minConfirms)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSendFromCmd(fromAccount, addr, amount.ToBTC(),
+		&minConfirms, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -690,14 +606,9 @@ func (c *Client) SendFromCommentAsync(fromAccount string,
 	toAddress btcutil.Address, amount btcutil.Amount, minConfirms int,
 	comment, commentTo string) FutureSendFromResult {
 
-	id := c.NextID()
 	addr := toAddress.EncodeAddress()
-	cmd, err := btcjson.NewSendFromCmd(id, fromAccount, addr, int64(amount),
-		minConfirms, comment, commentTo)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSendFromCmd(fromAccount, addr, amount.ToBTC(),
+		&minConfirms, &comment, &commentTo)
 	return c.sendCmd(cmd)
 }
 
@@ -750,16 +661,11 @@ func (r FutureSendManyResult) Receive() (*wire.ShaHash, error) {
 //
 // See SendMany for the blocking version and more details.
 func (c *Client) SendManyAsync(fromAccount string, amounts map[btcutil.Address]btcutil.Amount) FutureSendManyResult {
-	convertedAmounts := make(map[string]int64, len(amounts))
+	convertedAmounts := make(map[string]float64, len(amounts))
 	for addr, amount := range amounts {
-		convertedAmounts[addr.EncodeAddress()] = int64(amount)
+		convertedAmounts[addr.EncodeAddress()] = amount.ToBTC()
 	}
-	id := c.NextID()
-	cmd, err := btcjson.NewSendManyCmd(id, fromAccount, convertedAmounts)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSendManyCmd(fromAccount, convertedAmounts, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -784,17 +690,12 @@ func (c *Client) SendManyMinConfAsync(fromAccount string,
 	amounts map[btcutil.Address]btcutil.Amount,
 	minConfirms int) FutureSendManyResult {
 
-	convertedAmounts := make(map[string]int64, len(amounts))
+	convertedAmounts := make(map[string]float64, len(amounts))
 	for addr, amount := range amounts {
-		convertedAmounts[addr.EncodeAddress()] = int64(amount)
+		convertedAmounts[addr.EncodeAddress()] = amount.ToBTC()
 	}
-	id := c.NextID()
-	cmd, err := btcjson.NewSendManyCmd(id, fromAccount, convertedAmounts,
-		minConfirms)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSendManyCmd(fromAccount, convertedAmounts,
+		&minConfirms, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -823,17 +724,12 @@ func (c *Client) SendManyCommentAsync(fromAccount string,
 	amounts map[btcutil.Address]btcutil.Amount, minConfirms int,
 	comment string) FutureSendManyResult {
 
-	convertedAmounts := make(map[string]int64, len(amounts))
+	convertedAmounts := make(map[string]float64, len(amounts))
 	for addr, amount := range amounts {
-		convertedAmounts[addr.EncodeAddress()] = int64(amount)
+		convertedAmounts[addr.EncodeAddress()] = amount.ToBTC()
 	}
-	id := c.NextID()
-	cmd, err := btcjson.NewSendManyCmd(id, fromAccount, convertedAmounts,
-		minConfirms, comment)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSendManyCmd(fromAccount, convertedAmounts,
+		&minConfirms, &comment)
 	return c.sendCmd(cmd)
 }
 
@@ -888,18 +784,12 @@ func (r FutureAddMultisigAddressResult) Receive() (btcutil.Address, error) {
 //
 // See AddMultisigAddress for the blocking version and more details.
 func (c *Client) AddMultisigAddressAsync(requiredSigs int, addresses []btcutil.Address, account string) FutureAddMultisigAddressResult {
-	id := c.NextID()
-
 	addrs := make([]string, 0, len(addresses))
 	for _, addr := range addresses {
 		addrs = append(addrs, addr.String())
 	}
 
-	cmd, err := btcjson.NewAddMultisigAddressCmd(id, requiredSigs, addrs, account)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewAddMultisigAddressCmd(requiredSigs, addrs, &account)
 	return c.sendCmd(cmd)
 }
 
@@ -938,18 +828,12 @@ func (r FutureCreateMultisigResult) Receive() (*btcjson.CreateMultiSigResult, er
 //
 // See CreateMultisig for the blocking version and more details.
 func (c *Client) CreateMultisigAsync(requiredSigs int, addresses []btcutil.Address) FutureCreateMultisigResult {
-	id := c.NextID()
-
 	addrs := make([]string, 0, len(addresses))
 	for _, addr := range addresses {
 		addrs = append(addrs, addr.String())
 	}
 
-	cmd, err := btcjson.NewCreateMultisigCmd(id, requiredSigs, addrs)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewCreateMultisigCmd(requiredSigs, addrs)
 	return c.sendCmd(cmd)
 }
 
@@ -981,8 +865,7 @@ func (r FutureCreateNewAccountResult) Receive() error {
 //
 // See CreateNewAccount for the blocking version and more details.
 func (c *Client) CreateNewAccountAsync(account string) FutureCreateNewAccountResult {
-	id := c.NextID()
-	cmd := btcws.NewCreateNewAccountCmd(id, account)
+	cmd := btcjson.NewCreateNewAccountCmd(account)
 	return c.sendCmd(cmd)
 }
 
@@ -1019,12 +902,7 @@ func (r FutureGetNewAddressResult) Receive() (btcutil.Address, error) {
 //
 // See GetNewAddress for the blocking version and more details.
 func (c *Client) GetNewAddressAsync() FutureGetNewAddressResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetNewAddressCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetNewAddressCmd(nil)
 	return c.sendCmd(cmd)
 }
 
@@ -1062,12 +940,7 @@ func (r FutureGetRawChangeAddressResult) Receive() (btcutil.Address, error) {
 //
 // See GetRawChangeAddress for the blocking version and more details.
 func (c *Client) GetRawChangeAddressAsync(account string) FutureGetRawChangeAddressResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetRawChangeAddressCmd(id, account)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetRawChangeAddressCmd(&account)
 	return c.sendCmd(cmd)
 }
 
@@ -1106,12 +979,7 @@ func (r FutureGetAccountAddressResult) Receive() (btcutil.Address, error) {
 //
 // See GetAccountAddress for the blocking version and more details.
 func (c *Client) GetAccountAddressAsync(account string) FutureGetAccountAddressResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetAccountAddressCmd(id, account)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetAccountAddressCmd(account)
 	return c.sendCmd(cmd)
 }
 
@@ -1149,13 +1017,8 @@ func (r FutureGetAccountResult) Receive() (string, error) {
 //
 // See GetAccount for the blocking version and more details.
 func (c *Client) GetAccountAsync(address btcutil.Address) FutureGetAccountResult {
-	id := c.NextID()
 	addr := address.EncodeAddress()
-	cmd, err := btcjson.NewGetAccountCmd(id, addr)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetAccountCmd(addr)
 	return c.sendCmd(cmd)
 }
 
@@ -1185,13 +1048,8 @@ func (r FutureSetAccountResult) Receive() error {
 //
 // See SetAccount for the blocking version and more details.
 func (c *Client) SetAccountAsync(address btcutil.Address, account string) FutureSetAccountResult {
-	id := c.NextID()
 	addr := address.EncodeAddress()
-	cmd, err := btcjson.NewSetAccountCmd(id, addr, account)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSetAccountCmd(addr, account)
 	return c.sendCmd(cmd)
 }
 
@@ -1238,12 +1096,7 @@ func (r FutureGetAddressesByAccountResult) Receive() ([]btcutil.Address, error) 
 //
 // See GetAddressesByAccount for the blocking version and more details.
 func (c *Client) GetAddressesByAccountAsync(account string) FutureGetAddressesByAccountResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetAddressesByAccountCmd(id, account)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetAddressesByAccountCmd(account)
 	return c.sendCmd(cmd)
 }
 
@@ -1282,12 +1135,8 @@ func (r FutureMoveResult) Receive() (bool, error) {
 //
 // See Move for the blocking version and more details.
 func (c *Client) MoveAsync(fromAccount, toAccount string, amount btcutil.Amount) FutureMoveResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewMoveCmd(id, fromAccount, toAccount, int64(amount))
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewMoveCmd(fromAccount, toAccount, amount.ToBTC(), nil,
+		nil)
 	return c.sendCmd(cmd)
 }
 
@@ -1307,13 +1156,8 @@ func (c *Client) Move(fromAccount, toAccount string, amount btcutil.Amount) (boo
 func (c *Client) MoveMinConfAsync(fromAccount, toAccount string,
 	amount btcutil.Amount, minConfirms int) FutureMoveResult {
 
-	id := c.NextID()
-	cmd, err := btcjson.NewMoveCmd(id, fromAccount, toAccount, int64(amount),
-		minConfirms)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewMoveCmd(fromAccount, toAccount, amount.ToBTC(),
+		&minConfirms, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -1335,13 +1179,8 @@ func (c *Client) MoveMinConf(fromAccount, toAccount string, amount btcutil.Amoun
 func (c *Client) MoveCommentAsync(fromAccount, toAccount string,
 	amount btcutil.Amount, minConfirms int, comment string) FutureMoveResult {
 
-	id := c.NextID()
-	cmd, err := btcjson.NewMoveCmd(id, fromAccount, toAccount, int64(amount),
-		minConfirms, comment)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewMoveCmd(fromAccount, toAccount, amount.ToBTC(),
+		&minConfirms, &comment)
 	return c.sendCmd(cmd)
 }
 
@@ -1378,15 +1217,14 @@ func (r FutureRenameAccountResult) Receive() error {
 // returned instance.
 //
 // See RenameAccount for the blocking version and more details.
-func (c *Client) RenameAccountAsync(oldaccount, newaccount string) FutureRenameAccountResult {
-	id := c.NextID()
-	cmd := btcws.NewRenameAccountCmd(id, oldaccount, newaccount)
+func (c *Client) RenameAccountAsync(oldAccount, newAccount string) FutureRenameAccountResult {
+	cmd := btcjson.NewRenameAccountCmd(oldAccount, newAccount)
 	return c.sendCmd(cmd)
 }
 
 // RenameAccount creates a new wallet account.
-func (c *Client) RenameAccount(oldaccount, newaccount string) error {
-	return c.RenameAccountAsync(oldaccount, newaccount).Receive()
+func (c *Client) RenameAccount(oldAccount, newAccount string) error {
+	return c.RenameAccountAsync(oldAccount, newAccount).Receive()
 }
 
 // FutureValidateAddressResult is a future promise to deliver the result of a
@@ -1395,14 +1233,14 @@ type FutureValidateAddressResult chan *response
 
 // Receive waits for the response promised by the future and returns information
 // about the given bitcoin address.
-func (r FutureValidateAddressResult) Receive() (*btcjson.ValidateAddressResult, error) {
+func (r FutureValidateAddressResult) Receive() (*btcjson.ValidateAddressWalletResult, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
 	}
 
 	// Unmarshal result as a validateaddress result object.
-	var addrResult btcjson.ValidateAddressResult
+	var addrResult btcjson.ValidateAddressWalletResult
 	err = json.Unmarshal(res, &addrResult)
 	if err != nil {
 		return nil, err
@@ -1417,18 +1255,13 @@ func (r FutureValidateAddressResult) Receive() (*btcjson.ValidateAddressResult, 
 //
 // See ValidateAddress for the blocking version and more details.
 func (c *Client) ValidateAddressAsync(address btcutil.Address) FutureValidateAddressResult {
-	id := c.NextID()
 	addr := address.EncodeAddress()
-	cmd, err := btcjson.NewValidateAddressCmd(id, addr)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewValidateAddressCmd(addr)
 	return c.sendCmd(cmd)
 }
 
 // ValidateAddress returns information about the given bitcoin address.
-func (c *Client) ValidateAddress(address btcutil.Address) (*btcjson.ValidateAddressResult, error) {
+func (c *Client) ValidateAddress(address btcutil.Address) (*btcjson.ValidateAddressWalletResult, error) {
 	return c.ValidateAddressAsync(address).Receive()
 }
 
@@ -1453,12 +1286,7 @@ func (r FutureKeyPoolRefillResult) Receive() error {
 //
 // See KeyPoolRefill for the blocking version and more details.
 func (c *Client) KeyPoolRefillAsync() FutureKeyPoolRefillResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewKeyPoolRefillCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewKeyPoolRefillCmd(nil)
 	return c.sendCmd(cmd)
 }
 
@@ -1475,12 +1303,7 @@ func (c *Client) KeyPoolRefill() error {
 //
 // See KeyPoolRefillSize for the blocking version and more details.
 func (c *Client) KeyPoolRefillSizeAsync(newSize uint) FutureKeyPoolRefillResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewKeyPoolRefillCmd(id, newSize)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewKeyPoolRefillCmd(&newSize)
 	return c.sendCmd(cmd)
 }
 
@@ -1516,12 +1339,12 @@ func (r FutureListAccountsResult) Receive() (map[string]btcutil.Amount, error) {
 
 	accountsMap := make(map[string]btcutil.Amount)
 	for k, v := range accounts {
-		satoshi, err := btcjson.JSONToAmount(v)
+		amount, err := btcutil.NewAmount(v)
 		if err != nil {
 			return nil, err
 		}
 
-		accountsMap[k] = btcutil.Amount(satoshi)
+		accountsMap[k] = amount
 	}
 
 	return accountsMap, nil
@@ -1533,12 +1356,7 @@ func (r FutureListAccountsResult) Receive() (map[string]btcutil.Amount, error) {
 //
 // See ListAccounts for the blocking version and more details.
 func (c *Client) ListAccountsAsync() FutureListAccountsResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListAccountsCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListAccountsCmd(nil)
 	return c.sendCmd(cmd)
 }
 
@@ -1556,12 +1374,7 @@ func (c *Client) ListAccounts() (map[string]btcutil.Amount, error) {
 //
 // See ListAccountsMinConf for the blocking version and more details.
 func (c *Client) ListAccountsMinConfAsync(minConfirms int) FutureListAccountsResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListAccountsCmd(id, minConfirms)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListAccountsCmd(&minConfirms)
 	return c.sendCmd(cmd)
 }
 
@@ -1593,12 +1406,12 @@ func (r FutureGetBalanceResult) Receive() (btcutil.Amount, error) {
 		return 0, err
 	}
 
-	satoshi, err := btcjson.JSONToAmount(balance)
+	amount, err := btcutil.NewAmount(balance)
 	if err != nil {
 		return 0, err
 	}
 
-	return btcutil.Amount(satoshi), nil
+	return amount, nil
 }
 
 // FutureGetBalanceParseResult is same as FutureGetBalanceResult except
@@ -1626,12 +1439,12 @@ func (r FutureGetBalanceParseResult) Receive() (btcutil.Amount, error) {
 	if err != nil {
 		return 0, err
 	}
-	satoshi, err := btcjson.JSONToAmount(balance)
+	amount, err := btcutil.NewAmount(balance)
 	if err != nil {
 		return 0, err
 	}
 
-	return btcutil.Amount(satoshi), nil
+	return amount, nil
 }
 
 // GetBalanceAsync returns an instance of a type that can be used to get the
@@ -1640,16 +1453,7 @@ func (r FutureGetBalanceParseResult) Receive() (btcutil.Amount, error) {
 //
 // See GetBalance for the blocking version and more details.
 func (c *Client) GetBalanceAsync(account string) FutureGetBalanceResult {
-	// TODO(davec): Remove this hack once btcwallet is fixed.
-	if account == "*" {
-		account = ""
-	}
-	id := c.NextID()
-	cmd, err := btcjson.NewGetBalanceCmd(id, account)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetBalanceCmd(&account, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -1668,16 +1472,7 @@ func (c *Client) GetBalance(account string) (btcutil.Amount, error) {
 //
 // See GetBalanceMinConf for the blocking version and more details.
 func (c *Client) GetBalanceMinConfAsync(account string, minConfirms int) FutureGetBalanceResult {
-	// TODO(davec): Remove this hack once btcwallet is fixed.
-	if account == "*" {
-		account = ""
-	}
-	id := c.NextID()
-	cmd, err := btcjson.NewGetBalanceCmd(id, account, minConfirms)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetBalanceCmd(&account, &minConfirms)
 	return c.sendCmd(cmd)
 }
 
@@ -1714,12 +1509,12 @@ func (r FutureGetReceivedByAccountResult) Receive() (btcutil.Amount, error) {
 		return 0, err
 	}
 
-	satoshi, err := btcjson.JSONToAmount(balance)
+	amount, err := btcutil.NewAmount(balance)
 	if err != nil {
 		return 0, err
 	}
 
-	return btcutil.Amount(satoshi), nil
+	return amount, nil
 }
 
 // GetReceivedByAccountAsync returns an instance of a type that can be used to
@@ -1728,12 +1523,7 @@ func (r FutureGetReceivedByAccountResult) Receive() (btcutil.Amount, error) {
 //
 // See GetReceivedByAccount for the blocking version and more details.
 func (c *Client) GetReceivedByAccountAsync(account string) FutureGetReceivedByAccountResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetReceivedByAccountCmd(id, account)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetReceivedByAccountCmd(account, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -1752,12 +1542,7 @@ func (c *Client) GetReceivedByAccount(account string) (btcutil.Amount, error) {
 //
 // See GetReceivedByAccountMinConf for the blocking version and more details.
 func (c *Client) GetReceivedByAccountMinConfAsync(account string, minConfirms int) FutureGetReceivedByAccountResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetReceivedByAccountCmd(id, account, minConfirms)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetReceivedByAccountCmd(account, &minConfirms)
 	return c.sendCmd(cmd)
 }
 
@@ -1789,12 +1574,12 @@ func (r FutureGetUnconfirmedBalanceResult) Receive() (btcutil.Amount, error) {
 		return 0, err
 	}
 
-	satoshi, err := btcjson.JSONToAmount(balance)
+	amount, err := btcutil.NewAmount(balance)
 	if err != nil {
 		return 0, err
 	}
 
-	return btcutil.Amount(satoshi), nil
+	return amount, nil
 }
 
 // GetUnconfirmedBalanceAsync returns an instance of a type that can be used to
@@ -1803,12 +1588,7 @@ func (r FutureGetUnconfirmedBalanceResult) Receive() (btcutil.Amount, error) {
 //
 // See GetUnconfirmedBalance for the blocking version and more details.
 func (c *Client) GetUnconfirmedBalanceAsync(account string) FutureGetUnconfirmedBalanceResult {
-	id := c.NextID()
-	cmd, err := btcws.NewGetUnconfirmedBalanceCmd(id, account)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetUnconfirmedBalanceCmd(&account)
 	return c.sendCmd(cmd)
 }
 
@@ -1838,12 +1618,12 @@ func (r FutureGetReceivedByAddressResult) Receive() (btcutil.Amount, error) {
 		return 0, err
 	}
 
-	satoshi, err := btcjson.JSONToAmount(balance)
+	amount, err := btcutil.NewAmount(balance)
 	if err != nil {
 		return 0, err
 	}
 
-	return btcutil.Amount(satoshi), nil
+	return amount, nil
 }
 
 // GetReceivedByAddressAsync returns an instance of a type that can be used to
@@ -1852,13 +1632,8 @@ func (r FutureGetReceivedByAddressResult) Receive() (btcutil.Amount, error) {
 //
 // See GetReceivedByAddress for the blocking version and more details.
 func (c *Client) GetReceivedByAddressAsync(address btcutil.Address) FutureGetReceivedByAddressResult {
-	id := c.NextID()
 	addr := address.EncodeAddress()
-	cmd, err := btcjson.NewGetReceivedByAddressCmd(id, addr)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetReceivedByAddressCmd(addr, nil)
 	return c.sendCmd(cmd)
 
 }
@@ -1878,13 +1653,8 @@ func (c *Client) GetReceivedByAddress(address btcutil.Address) (btcutil.Amount, 
 //
 // See GetReceivedByAddressMinConf for the blocking version and more details.
 func (c *Client) GetReceivedByAddressMinConfAsync(address btcutil.Address, minConfirms int) FutureGetReceivedByAddressResult {
-	id := c.NextID()
 	addr := address.EncodeAddress()
-	cmd, err := btcjson.NewGetReceivedByAddressCmd(id, addr, minConfirms)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetReceivedByAddressCmd(addr, &minConfirms)
 	return c.sendCmd(cmd)
 }
 
@@ -1926,12 +1696,7 @@ func (r FutureListReceivedByAccountResult) Receive() ([]btcjson.ListReceivedByAc
 //
 // See ListReceivedByAccount for the blocking version and more details.
 func (c *Client) ListReceivedByAccountAsync() FutureListReceivedByAccountResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListReceivedByAccountCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListReceivedByAccountCmd(nil, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -1952,12 +1717,7 @@ func (c *Client) ListReceivedByAccount() ([]btcjson.ListReceivedByAccountResult,
 //
 // See ListReceivedByAccountMinConf for the blocking version and more details.
 func (c *Client) ListReceivedByAccountMinConfAsync(minConfirms int) FutureListReceivedByAccountResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListReceivedByAccountCmd(id, minConfirms)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListReceivedByAccountCmd(&minConfirms, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -1978,12 +1738,8 @@ func (c *Client) ListReceivedByAccountMinConf(minConfirms int) ([]btcjson.ListRe
 //
 // See ListReceivedByAccountIncludeEmpty for the blocking version and more details.
 func (c *Client) ListReceivedByAccountIncludeEmptyAsync(minConfirms int, includeEmpty bool) FutureListReceivedByAccountResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListReceivedByAccountCmd(id, minConfirms, includeEmpty)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListReceivedByAccountCmd(&minConfirms, &includeEmpty,
+		nil)
 	return c.sendCmd(cmd)
 }
 
@@ -2027,12 +1783,7 @@ func (r FutureListReceivedByAddressResult) Receive() ([]btcjson.ListReceivedByAd
 //
 // See ListReceivedByAddress for the blocking version and more details.
 func (c *Client) ListReceivedByAddressAsync() FutureListReceivedByAddressResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListReceivedByAddressCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListReceivedByAddressCmd(nil, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -2053,12 +1804,7 @@ func (c *Client) ListReceivedByAddress() ([]btcjson.ListReceivedByAddressResult,
 //
 // See ListReceivedByAddressMinConf for the blocking version and more details.
 func (c *Client) ListReceivedByAddressMinConfAsync(minConfirms int) FutureListReceivedByAddressResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListReceivedByAddressCmd(id, minConfirms)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListReceivedByAddressCmd(&minConfirms, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -2079,13 +1825,8 @@ func (c *Client) ListReceivedByAddressMinConf(minConfirms int) ([]btcjson.ListRe
 //
 // See ListReceivedByAccountIncludeEmpty for the blocking version and more details.
 func (c *Client) ListReceivedByAddressIncludeEmptyAsync(minConfirms int, includeEmpty bool) FutureListReceivedByAddressResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewListReceivedByAddressCmd(id, minConfirms,
-		includeEmpty)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewListReceivedByAddressCmd(&minConfirms, &includeEmpty,
+		nil)
 	return c.sendCmd(cmd)
 }
 
@@ -2124,12 +1865,7 @@ func (r FutureWalletLockResult) Receive() error {
 //
 // See WalletLock for the blocking version and more details.
 func (c *Client) WalletLockAsync() FutureWalletLockResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewWalletLockCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewWalletLockCmd()
 	return c.sendCmd(cmd)
 }
 
@@ -2146,13 +1882,8 @@ func (c *Client) WalletLock() error {
 // decryption key which is then stored in memory for the specified timeout
 // (in seconds).
 func (c *Client) WalletPassphrase(passphrase string, timeoutSecs int64) error {
-	id := c.NextID()
-	cmd, err := btcjson.NewWalletPassphraseCmd(id, passphrase, timeoutSecs)
-	if err != nil {
-		return err
-	}
-
-	_, err = c.sendCmdAndWait(cmd)
+	cmd := btcjson.NewWalletPassphraseCmd(passphrase, timeoutSecs)
+	_, err := c.sendCmdAndWait(cmd)
 	if err != nil {
 		return err
 	}
@@ -2181,12 +1912,7 @@ func (r FutureWalletPassphraseChangeResult) Receive() error {
 //
 // See WalletPassphraseChange for the blocking version and more details.
 func (c *Client) WalletPassphraseChangeAsync(old, new string) FutureWalletPassphraseChangeResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewWalletPassphraseChangeCmd(id, old, new)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewWalletPassphraseChangeCmd(old, new)
 	return c.sendCmd(cmd)
 }
 
@@ -2228,13 +1954,8 @@ func (r FutureSignMessageResult) Receive() (string, error) {
 //
 // See SignMessage for the blocking version and more details.
 func (c *Client) SignMessageAsync(address btcutil.Address, message string) FutureSignMessageResult {
-	id := c.NextID()
 	addr := address.EncodeAddress()
-	cmd, err := btcjson.NewSignMessageCmd(id, addr, message)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewSignMessageCmd(addr, message)
 	return c.sendCmd(cmd)
 }
 
@@ -2274,13 +1995,8 @@ func (r FutureVerifyMessageResult) Receive() (bool, error) {
 //
 // See VerifyMessage for the blocking version and more details.
 func (c *Client) VerifyMessageAsync(address btcutil.Address, signature, message string) FutureVerifyMessageResult {
-	id := c.NextID()
 	addr := address.EncodeAddress()
-	cmd, err := btcjson.NewVerifyMessageCmd(id, addr, signature, message)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewVerifyMessageCmd(addr, signature, message)
 	return c.sendCmd(cmd)
 }
 
@@ -2325,13 +2041,8 @@ func (r FutureDumpPrivKeyResult) Receive() (*btcutil.WIF, error) {
 //
 // See DumpPrivKey for the blocking version and more details.
 func (c *Client) DumpPrivKeyAsync(address btcutil.Address) FutureDumpPrivKeyResult {
-	id := c.NextID()
 	addr := address.EncodeAddress()
-	cmd, err := btcjson.NewDumpPrivKeyCmd(id, addr)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewDumpPrivKeyCmd(addr)
 	return c.sendCmd(cmd)
 }
 
@@ -2371,12 +2082,7 @@ func (c *Client) ImportPrivKeyAsync(privKeyWIF *btcutil.WIF) FutureImportPrivKey
 		wif = privKeyWIF.String()
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewImportPrivKeyCmd(id, wif)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewImportPrivKeyCmd(wif, nil, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -2397,12 +2103,7 @@ func (c *Client) ImportPrivKeyLabelAsync(privKeyWIF *btcutil.WIF, label string) 
 		wif = privKeyWIF.String()
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewImportPrivKeyCmd(id, wif, label)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewImportPrivKeyCmd(wif, &label, nil)
 	return c.sendCmd(cmd)
 }
 
@@ -2423,12 +2124,7 @@ func (c *Client) ImportPrivKeyRescanAsync(privKeyWIF *btcutil.WIF, label string,
 		wif = privKeyWIF.String()
 	}
 
-	id := c.NextID()
-	cmd, err := btcjson.NewImportPrivKeyCmd(id, wif, label, rescan)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewImportPrivKeyCmd(wif, &label, &rescan)
 	return c.sendCmd(cmd)
 }
 
@@ -2452,14 +2148,14 @@ type FutureGetInfoResult chan *response
 
 // Receive waits for the response promised by the future and returns the info
 // provided by the server.
-func (r FutureGetInfoResult) Receive() (*btcjson.InfoResult, error) {
+func (r FutureGetInfoResult) Receive() (*btcjson.InfoWalletResult, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
 	}
 
 	// Unmarshal result as a getinfo result object.
-	var infoRes btcjson.InfoResult
+	var infoRes btcjson.InfoWalletResult
 	err = json.Unmarshal(res, &infoRes)
 	if err != nil {
 		return nil, err
@@ -2474,19 +2170,14 @@ func (r FutureGetInfoResult) Receive() (*btcjson.InfoResult, error) {
 //
 // See GetInfo for the blocking version and more details.
 func (c *Client) GetInfoAsync() FutureGetInfoResult {
-	id := c.NextID()
-	cmd, err := btcjson.NewGetInfoCmd(id)
-	if err != nil {
-		return newFutureError(err)
-	}
-
+	cmd := btcjson.NewGetInfoCmd()
 	return c.sendCmd(cmd)
 }
 
 // GetInfo returns miscellaneous info regarding the RPC server.  The returned
 // info object may be void of wallet information if the remote server does
 // not include wallet functionality.
-func (c *Client) GetInfo() (*btcjson.InfoResult, error) {
+func (c *Client) GetInfo() (*btcjson.InfoWalletResult, error) {
 	return c.GetInfoAsync().Receive()
 }
 

--- a/wallet.go
+++ b/wallet.go
@@ -2055,6 +2055,52 @@ func (c *Client) DumpPrivKey(address btcutil.Address) (*btcutil.WIF, error) {
 	return c.DumpPrivKeyAsync(address).Receive()
 }
 
+// FutureImportAddressResult is a future promise to deliver the result of an
+// ImportAddressAsync RPC invocation (or an applicable error).
+type FutureImportAddressResult chan *response
+
+// Receive waits for the response promised by the future and returns the result
+// of importing the passed public address.
+func (r FutureImportAddressResult) Receive() error {
+	_, err := receiveFuture(r)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ImportAddressAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+//
+// See ImportAddress for the blocking version and more details.
+func (c *Client) ImportAddressAsync(address string) FutureImportAddressResult {
+	cmd := btcjson.NewImportAddressCmd(address, nil)
+	return c.sendCmd(cmd)
+}
+
+// ImportAddress imports the passed public address.
+func (c *Client) ImportAddress(address string) error {
+	return c.ImportAddressAsync(address).Receive()
+}
+
+// ImportAddressRescanAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+//
+// See ImportAddress for the blocking version and more details.
+func (c *Client) ImportAddressRescanAsync(address string, rescan bool) FutureImportAddressResult {
+	cmd := btcjson.NewImportAddressCmd(address, &rescan)
+	return c.sendCmd(cmd)
+}
+
+// ImportAddressRescan imports the passed public address. When rescan is true,
+// the block history is scanned for transactions addressed to provided address.
+func (c *Client) ImportAddressRescan(address string, rescan bool) error {
+	return c.ImportAddressRescanAsync(address, rescan).Receive()
+}
+
 // FutureImportPrivKeyResult is a future promise to deliver the result of an
 // ImportPrivKeyAsync RPC invocation (or an applicable error).
 type FutureImportPrivKeyResult chan *response
@@ -2133,6 +2179,52 @@ func (c *Client) ImportPrivKeyRescanAsync(privKeyWIF *btcutil.WIF, label string,
 // the block history is scanned for transactions addressed to provided privKey.
 func (c *Client) ImportPrivKeyRescan(privKeyWIF *btcutil.WIF, label string, rescan bool) error {
 	return c.ImportPrivKeyRescanAsync(privKeyWIF, label, rescan).Receive()
+}
+
+// FutureImportPubKeyResult is a future promise to deliver the result of an
+// ImportPubKeyAsync RPC invocation (or an applicable error).
+type FutureImportPubKeyResult chan *response
+
+// Receive waits for the response promised by the future and returns the result
+// of importing the passed public key.
+func (r FutureImportPubKeyResult) Receive() error {
+	_, err := receiveFuture(r)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ImportPubKeyAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+//
+// See ImportPubKey for the blocking version and more details.
+func (c *Client) ImportPubKeyAsync(pubKey string) FutureImportPubKeyResult {
+	cmd := btcjson.NewImportPubKeyCmd(pubKey, nil)
+	return c.sendCmd(cmd)
+}
+
+// ImportPubKey imports the passed public key.
+func (c *Client) ImportPubKey(pubKey string) error {
+	return c.ImportPubKeyAsync(pubKey).Receive()
+}
+
+// ImportPubKeyRescanAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+//
+// See ImportPubKey for the blocking version and more details.
+func (c *Client) ImportPubKeyRescanAsync(pubKey string, rescan bool) FutureImportPubKeyResult {
+	cmd := btcjson.NewImportPubKeyCmd(pubKey, &rescan)
+	return c.sendCmd(cmd)
+}
+
+// ImportPubKeyRescan imports the passed public key. When rescan is true, the
+// block history is scanned for transactions addressed to provided pubkey.
+func (c *Client) ImportPubKeyRescan(pubKey string, rescan bool) error {
+	return c.ImportPubKeyRescanAsync(pubKey, rescan).Receive()
 }
 
 // ***********************


### PR DESCRIPTION
Requires conformal/btcjson#34.

This pull request contains several changes needed to update the client to use the upcoming version 2 of btcjson.  In addition it contains a couple of other minor changes along the way.

While the underlying changes are quite large, the public API of this package is still the same, so caller should generally not have to update their code due to that.  However, the underlying btcjson package API has
changed significantly.  Since this package hides the vast majority of that from callers, it should not afffect them very much.  However, one area in particular to watch out for is that the old btcjson.Error is now btcjson.RPCError, so any callers doing any type assertions there will need to update.

The following is a summary of the changes:

- The underlying btcjson significantly changed how commands work, so the internals of this package have been reworked to be based off of requests instead of the now non-existant btcjson.Cmd interface
- Update all call sites of btcjson.New<Foo>Cmd since they can no longer error or take varargs
- The ids for each request are part of the request now instead of the command to match the new btcjson model and are strict uint64s so type assertions are no longer needed (slightly improved efficiency)
- Remove the old temporary workaround for the getbalance command with an account of "*" since btcwallet has since been fixed
- Change all instances of JSONToAmount to btcutil.NewAmount since that function was removed in favor of btcutil.Amount
- Change all btcws invocations to btcjson since they have been combined