### PR TITLE
Add account param on GetNewAddress

### DIFF
--- a/wallet.go
+++ b/wallet.go
@@ -901,14 +901,14 @@ func (r FutureGetNewAddressResult) Receive() (btcutil.Address, error) {
 // returned instance.
 //
 // See GetNewAddress for the blocking version and more details.
-func (c *Client) GetNewAddressAsync() FutureGetNewAddressResult {
-	cmd := btcjson.NewGetNewAddressCmd(nil)
+func (c *Client) GetNewAddressAsync(account string) FutureGetNewAddressResult {
+	cmd := btcjson.NewGetNewAddressCmd(&account)
 	return c.sendCmd(cmd)
 }
 
 // GetNewAddress returns a new address.
-func (c *Client) GetNewAddress() (btcutil.Address, error) {
-	return c.GetNewAddressAsync().Receive()
+func (c *Client) GetNewAddress(account string) (btcutil.Address, error) {
+	return c.GetNewAddressAsync(account).Receive()
 }
 
 // FutureGetRawChangeAddressResult is a future promise to deliver the result of


### PR DESCRIPTION
https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_calls_list

getnewaddress get an optional account parameter.This parameter is missing on btcrpcclient, so I added it. It's still possible to add the address in default account using 'nil'.

