### PR TITLE
verboseTx params makes GetBlocKVerbose fail

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -140,7 +140,7 @@ func (c *Client) GetBlockVerboseAsync(blockHash *wire.ShaHash, verboseTx bool) F
 		hash = blockHash.String()
 	}
 
-	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Bool(true), &verboseTx)
+	cmd := btcjson.NewGetBlockCmd(hash, btcjson.Bool(true), nil)
 	return c.sendCmd(cmd)
 }
 


### PR DESCRIPTION
**This is not the fix** , I just wanted to raise the issue.

This change "fix" the problem, but it's clearly wrong. I'm still reviewing the code, so not sure what changes should be made.

**SYMPTONS**
Calling function getBlockVerbose or GetBlockVerboseAsync returns an error, no matter which parameters are used. Error message at the end


**HOW TO REPRODUCE**
```go
hash, err := client.GetBlockHash(100)
if err != nil {
	log.Fatal(err)
}

block, err := client.GetBlock(hash)
if err != nil { // err is nil
	log.Fatal(err) 
}
blockverbose, err := client.GetBlockVerbose(hash, true) //no matter is true or false is used, error is triggered always
if err != nil { 
	log.Fatal(err) 
}
```


**NOTE** 

Same error message is achieved directly with bitcoin-cli if a second bool parameter (verboseTx) is used

All of these fails
```bash
bitcoin-cli getblock 000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a true true
bitcoin-cli getblock 000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a true false
bitcoin-cli getblock 000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a false true
bitcoin-cli getblock 000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a false false
```

These works
```bash
bitcoin-cli getblock 000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a true
bitcoin-cli getblock 000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a false
```


Thus forcing verboseTx to nil, "fix" the issue, but verboseTx is still in the code.




**ERROR MESSAGE**
error: {"code":-1,"message":"getblock "hash" ( verbose )

If verbose is false, returns a string that is serialized, hex-encoded data for block 'hash'.
If verbose is true, returns an Object with information about block <hash>.
Arguments:
1. "hash"          (string, required) The block hash
2. verbose           (boolean, optional, default=true) true for a json object, false for the hex encoded data

Result (for verbose = true):
{
  "hash" : "hash",     (string) the block hash (same as provided)
  "confirmations" : n,   (numeric) The number of confirmations, or -1 if the block is not on the main chain
  "size" : n,            (numeric) The block size
  "height" : n,          (numeric) The block height or index
  "version" : n,         (numeric) The block version
  "merkleroot" : "xxxx", (string) The merkle root
  "tx" : [               (array of string) The transaction ids
     "transactionid"     (string) The transaction id
     ,...
  ],
  "time" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)
  "nonce" : n,           (numeric) The nonce
  "bits" : "1d00ffff", (string) The bits
  "difficulty" : x.xxx,  (numeric) The difficulty
  "previousblockhash" : "hash",  (string) The hash of the previous block
  "nextblockhash" : "hash"       (string) The hash of the next block
}

Result (for verbose=false):
"data"             (string) A string that is serialized, hex-encoded data for block 'hash'.

Examples:
> bitcoin-cli getblock "00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09"
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "getblock", "params": ["00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09"] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/
"}