### PR TITLE
Update SearchRawTransaction calls for latest API.

### DIFF
--- a/rawtransactions.go
+++ b/rawtransactions.go
@@ -549,11 +549,11 @@ func (r FutureSearchRawTransactionsResult) Receive() ([]*wire.MsgTx, error) {
 // function on the returned instance.
 //
 // See SearchRawTransactions for the blocking version and more details.
-func (c *Client) SearchRawTransactionsAsync(address btcutil.Address, skip, count int) FutureSearchRawTransactionsResult {
+func (c *Client) SearchRawTransactionsAsync(address btcutil.Address, skip, count int, reverse bool) FutureSearchRawTransactionsResult {
 	addr := address.EncodeAddress()
 	verbose := btcjson.Int(0)
 	cmd := btcjson.NewSearchRawTransactionsCmd(addr, verbose, &skip, &count,
-		nil)
+		nil, &reverse)
 	return c.sendCmd(cmd)
 }
 
@@ -564,8 +564,8 @@ func (c *Client) SearchRawTransactionsAsync(address btcutil.Address, skip, count
 //
 // See SearchRawTransactionsVerbose to retrieve a list of data structures with
 // information about the transactions instead of the transactions themselves.
-func (c *Client) SearchRawTransactions(address btcutil.Address, skip, count int) ([]*wire.MsgTx, error) {
-	return c.SearchRawTransactionsAsync(address, skip, count).Receive()
+func (c *Client) SearchRawTransactions(address btcutil.Address, skip, count int, reverse bool) ([]*wire.MsgTx, error) {
+	return c.SearchRawTransactionsAsync(address, skip, count, reverse).Receive()
 }
 
 // FutureSearchRawTransactionsVerboseResult is a future promise to deliver the
@@ -597,7 +597,7 @@ func (r FutureSearchRawTransactionsVerboseResult) Receive() ([]*btcjson.SearchRa
 //
 // See SearchRawTransactionsVerbose for the blocking version and more details.
 func (c *Client) SearchRawTransactionsVerboseAsync(address btcutil.Address, skip,
-	count int, includePrevOut bool) FutureSearchRawTransactionsVerboseResult {
+	count int, includePrevOut, reverse bool) FutureSearchRawTransactionsVerboseResult {
 
 	addr := address.EncodeAddress()
 	verbose := btcjson.Int(1)
@@ -606,7 +606,7 @@ func (c *Client) SearchRawTransactionsVerboseAsync(address btcutil.Address, skip
 		prevOut = btcjson.Int(1)
 	}
 	cmd := btcjson.NewSearchRawTransactionsCmd(addr, verbose, &skip, &count,
-		prevOut)
+		prevOut, &reverse)
 	return c.sendCmd(cmd)
 }
 
@@ -618,8 +618,8 @@ func (c *Client) SearchRawTransactionsVerboseAsync(address btcutil.Address, skip
 //
 // See SearchRawTransactions to retrieve a list of raw transactions instead.
 func (c *Client) SearchRawTransactionsVerbose(address btcutil.Address, skip,
-	count int, includePrevOut bool) ([]*btcjson.SearchRawTransactionsResult, error) {
+	count int, includePrevOut, reverse bool) ([]*btcjson.SearchRawTransactionsResult, error) {
 
 	return c.SearchRawTransactionsVerboseAsync(address, skip, count,
-		includePrevOut).Receive()
+		includePrevOut, reverse).Receive()
 }


### PR DESCRIPTION
**This pull request depends on btcsuite/btcd#497**

This pull request modifies the `SearchRawTransactions` and `SearchRawTransactionsVerbose` functions to work properly with the latest `searchrawtransactions` API in btcd.

In particular, this involves adding a new parameter for the reverse option which specifies whether or not to include the results in reverse order.