### PR TITLE
Fix "Established connection" log message.

### DIFF
--- a/infrastructure.go
+++ b/infrastructure.go
@@ -1211,8 +1211,6 @@ func New(config *ConnConfig, ntfnHandlers *NotificationHandlers) (*Client, error
 			start = true
 		}
 	}
-	log.Infof("Established connection to RPC server %s",
-		config.Host)
 
 	client := &Client{
 		config:          config,
@@ -1230,6 +1228,8 @@ func New(config *ConnConfig, ntfnHandlers *NotificationHandlers) (*Client, error
 	}
 
 	if start {
+		log.Infof("Established connection to RPC server %s",
+			config.Host)
 		close(connEstablished)
 		client.start()
 		if !client.config.HTTPPostMode && !client.config.DisableAutoReconnect {
@@ -1282,6 +1282,8 @@ func (c *Client) Connect(tries int) error {
 		// Connection was established.  Set the websocket connection
 		// member of the client and start the goroutines necessary
 		// to run the client.
+		log.Infof("Established connection to RPC server %s",
+			c.config.Host)
 		c.wsConn = wsConn
 		close(c.connEstablished)
 		c.start()


### PR DESCRIPTION
Don't log "Established connection" message on New() when
DisableConnectOnNew is set and no connection was actually established.
Do log that same message when Connect() successfully connects.