### PR TITLE
Manually copy relevant fields in ntfn state copy.

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -47,7 +47,10 @@ func (s *notificationState) Copy() *notificationState {
 	s.Lock()
 	defer s.Unlock()
 
-	stateCopy := *s
+	var stateCopy notificationState
+	stateCopy.notifyBlocks = s.notifyBlocks
+	stateCopy.notifyNewTx = s.notifyNewTx
+	stateCopy.notifyNewTxVerbose = s.notifyNewTxVerbose
 	stateCopy.notifyReceived = make(map[string]struct{})
 	for addr := range s.notifyReceived {
 		stateCopy.notifyReceived[addr] = struct{}{}


### PR DESCRIPTION
This makes `go vet` happy by manually copying the notification state fields during the deep copy instead of copying the entire struct which contains an embedded mutex.