### PR TITLE
Allow user to set params

### DIFF
--- a/infrastructure.go
+++ b/infrastructure.go
@@ -26,9 +26,11 @@ import (
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/go-socks/socks"
 	"github.com/btcsuite/websocket"
+	"github.com/btcsuite/btcd/chaincfg"
 )
 
 var (
+	NetworkParams *chaincfg.Params = &chaincfg.MainNetParams
 	// ErrInvalidAuth is an error to describe the condition where the client
 	// is either unable to authenticate or the specified endpoint is
 	// incorrect.
@@ -116,6 +118,7 @@ type jsonRequest struct {
 // the returned future will block until the result is available if it's not
 // already.
 type Client struct {
+
 	id uint64 // atomic, so must stay 64-bit aligned
 
 	// config holds the connection configuration assoiated with this client.
@@ -1109,6 +1112,9 @@ type ConnConfig struct {
 	// EnableBCInfoHacks is an option provided to enable compatiblity hacks
 	// when connecting to blockchain.info RPC server
 	EnableBCInfoHacks bool
+
+	// Network Parameters
+	Params *chaincfg.Params
 }
 
 // newHTTPClient returns a new http client that is configured according to the
@@ -1243,6 +1249,10 @@ func New(config *ConnConfig, ntfnHandlers *NotificationHandlers) (*Client, error
 			}
 			start = true
 		}
+	}
+
+	if config.Params != nil {
+		NetworkParams = config.Params
 	}
 
 	client := &Client{

--- a/wallet.go
+++ b/wallet.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	"github.com/btcsuite/btcd/btcjson"
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -775,7 +774,7 @@ func (r FutureAddMultisigAddressResult) Receive() (btcutil.Address, error) {
 		return nil, err
 	}
 
-	return btcutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return btcutil.DecodeAddress(addr, NetworkParams)
 }
 
 // AddMultisigAddressAsync returns an instance of a type that can be used to get
@@ -893,7 +892,7 @@ func (r FutureGetNewAddressResult) Receive() (btcutil.Address, error) {
 		return nil, err
 	}
 
-	return btcutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return btcutil.DecodeAddress(addr, NetworkParams)
 }
 
 // GetNewAddressAsync returns an instance of a type that can be used to get the
@@ -931,7 +930,7 @@ func (r FutureGetRawChangeAddressResult) Receive() (btcutil.Address, error) {
 		return nil, err
 	}
 
-	return btcutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return btcutil.DecodeAddress(addr, NetworkParams)
 }
 
 // GetRawChangeAddressAsync returns an instance of a type that can be used to
@@ -970,7 +969,7 @@ func (r FutureGetAccountAddressResult) Receive() (btcutil.Address, error) {
 		return nil, err
 	}
 
-	return btcutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return btcutil.DecodeAddress(addr, NetworkParams)
 }
 
 // GetAccountAddressAsync returns an instance of a type that can be used to get
@@ -1080,7 +1079,7 @@ func (r FutureGetAddressesByAccountResult) Receive() ([]btcutil.Address, error) 
 	addrs := make([]btcutil.Address, 0, len(addrStrings))
 	for _, addrStr := range addrStrings {
 		addr, err := btcutil.DecodeAddress(addrStr,
-			&chaincfg.MainNetParams)
+			NetworkParams)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Currently can't use on testnet due to hardcoded mainnet params. This adds params to the config. 