### PR TITLE
Simplify code per gosimple linter.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -106,11 +106,7 @@ type FutureSetGenerateResult chan *response
 // any occurred when setting the server to generate coins (mine) or not.
 func (r FutureSetGenerateResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // SetGenerateAsync returns an instance of a type that can be used to get the

--- a/net.go
+++ b/net.go
@@ -41,11 +41,7 @@ type FutureAddNodeResult chan *response
 // any occurred when performing the specified command.
 func (r FutureAddNodeResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // AddNodeAsync returns an instance of a type that can be used to get the result
@@ -193,11 +189,7 @@ type FuturePingResult chan *response
 // of queueing a ping to be sent to each connected peer.
 func (r FuturePingResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // PingAsync returns an instance of a type that can be used to get the result of

--- a/notify.go
+++ b/notify.go
@@ -663,11 +663,7 @@ type FutureNotifyBlocksResult chan *response
 // if the registration was not successful.
 func (r FutureNotifyBlocksResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // NotifyBlocksAsync returns an instance of a type that can be used to get the
@@ -715,11 +711,7 @@ type FutureNotifySpentResult chan *response
 // if the registration was not successful.
 func (r FutureNotifySpentResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // notifySpentInternal is the same as notifySpentAsync except it accepts
@@ -799,11 +791,7 @@ type FutureNotifyNewTransactionsResult chan *response
 // if the registration was not successful.
 func (r FutureNotifyNewTransactionsResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // NotifyNewTransactionsAsync returns an instance of a type that can be used to
@@ -852,11 +840,7 @@ type FutureNotifyReceivedResult chan *response
 // if the registration was not successful.
 func (r FutureNotifyReceivedResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // notifyReceivedInternal is the same as notifyReceivedAsync except it accepts
@@ -936,11 +920,7 @@ type FutureRescanResult chan *response
 // if the rescan was not successful.
 func (r FutureRescanResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // RescanAsync returns an instance of a type that can be used to get the result

--- a/wallet.go
+++ b/wallet.go
@@ -423,11 +423,7 @@ type FutureSetTxFeeResult chan *response
 // are processed quickly.  Most transaction are 1KB.
 func (r FutureSetTxFeeResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // SetTxFeeAsync returns an instance of a type that can be used to get the
@@ -852,11 +848,7 @@ type FutureCreateNewAccountResult chan *response
 // result of creating new account.
 func (r FutureCreateNewAccountResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // CreateNewAccountAsync returns an instance of a type that can be used to get the
@@ -1035,11 +1027,7 @@ type FutureSetAccountResult chan *response
 // of setting the account to be associated with the passed address.
 func (r FutureSetAccountResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // SetAccountAsync returns an instance of a type that can be used to get the
@@ -1205,11 +1193,7 @@ type FutureRenameAccountResult chan *response
 // result of creating new account.
 func (r FutureRenameAccountResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // RenameAccountAsync returns an instance of a type that can be used to get the
@@ -1273,11 +1257,7 @@ type FutureKeyPoolRefillResult chan *response
 // of refilling the key pool.
 func (r FutureKeyPoolRefillResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // KeyPoolRefillAsync returns an instance of a type that can be used to get the
@@ -1852,11 +1832,7 @@ type FutureWalletLockResult chan *response
 // of locking the wallet.
 func (r FutureWalletLockResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // WalletLockAsync returns an instance of a type that can be used to get the
@@ -1884,11 +1860,7 @@ func (c *Client) WalletLock() error {
 func (c *Client) WalletPassphrase(passphrase string, timeoutSecs int64) error {
 	cmd := btcjson.NewWalletPassphraseCmd(passphrase, timeoutSecs)
 	_, err := c.sendCmdAndWait(cmd)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // FutureWalletPassphraseChangeResult is a future promise to deliver the result
@@ -1899,11 +1871,7 @@ type FutureWalletPassphraseChangeResult chan *response
 // of changing the wallet passphrase.
 func (r FutureWalletPassphraseChangeResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // WalletPassphraseChangeAsync returns an instance of a type that can be used to
@@ -2063,11 +2031,7 @@ type FutureImportAddressResult chan *response
 // of importing the passed public address.
 func (r FutureImportAddressResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // ImportAddressAsync returns an instance of a type that can be used to get the
@@ -2110,11 +2074,7 @@ type FutureImportPrivKeyResult chan *response
 // (WIF).
 func (r FutureImportPrivKeyResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // ImportPrivKeyAsync returns an instance of a type that can be used to get the
@@ -2189,11 +2149,7 @@ type FutureImportPubKeyResult chan *response
 // of importing the passed public key.
 func (r FutureImportPubKeyResult) Receive() error {
 	_, err := receiveFuture(r)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // ImportPubKeyAsync returns an instance of a type that can be used to get the


### PR DESCRIPTION
This simplifies the code based on the recommendations of the [gosimple](https://github.com/dominikh/go-simple) lint tool.