### PR TITLE
build: Add gosimple linter to goclean.sh.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -4,7 +4,8 @@
 # 2. goimports     (https://github.com/bradfitz/goimports)
 # 3. golint        (https://github.com/golang/lint)
 # 4. go vet        (http://golang.org/cmd/vet)
-# 5. test coverage (http://blog.golang.org/cover)
+# 5. gosimple      (https://github.com/dominikh/go-simple)
+# 6. test coverage (http://blog.golang.org/cover)
 #
 # gometalinter (github.com/alecthomas/gometalinter) is used to run each each
 # static checker.
@@ -16,8 +17,9 @@ test -z "$(gometalinter --disable-all \
 --enable=gofmt \
 --enable=golint \
 --enable=vet \
+--enable=gosimple \
 --enable=goimports \
---deadline=20s ./... | tee /dev/stderr)"
+--deadline=45s ./... | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -v -race ./...
 
 # Run test coverage on each subdirectories and merge the coverage profile.


### PR DESCRIPTION
This modifies the `goclean.sh` script to include the `gosimple` lint tool to the `gometalinter` configuration.