### PR TITLE
Remove unnecessary convs found by unconvert.

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -551,7 +551,7 @@ func parseTxAcceptedNtfnParams(params []json.RawMessage) (*chainhash.Hash,
 		return nil, 0, err
 	}
 
-	return txHash, btcutil.Amount(amt), nil
+	return txHash, amt, nil
 }
 
 // parseTxAcceptedVerboseNtfnParams parses out details about a raw transaction
@@ -628,7 +628,7 @@ func parseAccountBalanceNtfnParams(params []json.RawMessage) (account string,
 		return "", 0, false, err
 	}
 
-	return account, btcutil.Amount(bal), confirmed, nil
+	return account, bal, confirmed, nil
 }
 
 // parseWalletLockStateNtfnParams parses out the account name and locked


### PR DESCRIPTION
This removes all unnecessary typecast conversions as found by the [unconvert](https://github.com/mdempsky/unconvert) linter.