### PR TITLE
build: Add unconvert linter to goclean.sh.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -5,7 +5,8 @@
 # 3. golint        (https://github.com/golang/lint)
 # 4. go vet        (http://golang.org/cmd/vet)
 # 5. gosimple      (https://github.com/dominikh/go-simple)
-# 6. test coverage (http://blog.golang.org/cover)
+# 6. unconvert     (https://github.com/mdempsky/unconvert)
+# 7. test coverage (http://blog.golang.org/cover)
 #
 # gometalinter (github.com/alecthomas/gometalinter) is used to run each each
 # static checker.
@@ -18,6 +19,7 @@ test -z "$(gometalinter --disable-all \
 --enable=golint \
 --enable=vet \
 --enable=gosimple \
+--enable=unconvert \
 --enable=goimports \
 --deadline=45s ./... | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -v -race ./...


### PR DESCRIPTION
This modifies the `goclean.sh` script to include the `unconvert` lint tool in the `gometalinter` configuration.